### PR TITLE
🎈 LRU 高速缓冲

### DIFF
--- a/src/include/onix/buffer.h
+++ b/src/include/onix/buffer.h
@@ -11,15 +11,16 @@
 
 typedef struct buffer_t
 {
-    char *data;        // 数据区
-    dev_t dev;         // 设备号
-    idx_t block;       // 块号
-    int count;         // 引用计数
-    list_node_t hnode; // 哈希表拉链节点
-    list_node_t rnode; // 缓冲节点
-    lock_t lock;       // 锁
-    bool dirty;        // 是否与磁盘不一致
-    bool valid;        // 是否有效
+    char *data;              // 数据区
+    dev_t dev;               // 设备号
+    idx_t block;             // 块号
+    int count;               // 引用计数
+    list_node_t hash_node;   // 哈希表拉链节点
+    list_node_t in_use_node; // in_use 节点
+    list_node_t lru_node;    // lru 节点
+    lock_t lock;             // 锁
+    bool dirty;              // 是否与磁盘不一致
+    bool valid;              // 是否有效
 } buffer_t;
 
 buffer_t *getblk(dev_t dev, idx_t block);


### PR DESCRIPTION
旧版 `buffer` 设计明显不科学，我参考了大部分 `buffer` ，采用 `LRU` 策略最多，比如 `leveldb` 的 [cache](https://github.com/google/leveldb/blob/068d5ee1a3ac40dabd00d211d5013af44be55bea/util/cache.cc)。

对目前代码仅做了少量改动。

简单梳理一下`LRU`高速缓冲的实现：
1. `in_use_list` ：保存 `count > 0` 的 `buffer` 指针。
2.  `lru_list`：保存`count == 0` 的 `buffer` 指针。
3. `hash_table` ：标记 `in_use_list` 或 `lru_lsit` 中的 `buffer` 指针。
4. 只有 `lru_list` 淘汰节点的时候，`hash_table` 才删除标记。