### PR TITLE
🐛修复pathname为“..”时namei返回dir->super->imount的问题

### DIFF
--- a/src/fs/fsyscall.c
+++ b/src/fs/fsyscall.c
@@ -670,7 +670,9 @@ int sys_umount(char *target)
         LOGK("warning super block mount = 0\n");
     }
 
-    if (list_size(&super->inode_list) > 1)
+    if (list_size(&super->inode_list) > 1
+        || super->iroot->count != 1
+    )
     {
         ret = -EBUSY;
         goto rollback;

--- a/src/fs/fsyscall.c
+++ b/src/fs/fsyscall.c
@@ -33,9 +33,10 @@ fd_t sys_open(char *filename, int flags, int mode)
     if (ret < 0)
         goto rollback;
 
-makeup:
     file_t *file;
-    fd_t fd = fd_get(&file);
+    fd_t fd;
+makeup:
+    fd = fd_get(&file);
     if (fd < EOK)
         return fd;
 

--- a/src/fs/fsyscall.c
+++ b/src/fs/fsyscall.c
@@ -674,8 +674,8 @@ int sys_umount(char *target)
         || super->iroot->count != 1
     )
     {
-        ret = -EBUSY;
-        goto rollback;
+        iput(inode);
+        return -EBUSY;
     }
 
     iput(super->iroot);

--- a/src/fs/namei.c
+++ b/src/fs/namei.c
@@ -111,9 +111,15 @@ inode_t *namei(char *pathname)
     char *name = next;
     inode_t *inode = NULL;
 
-    if (match_name(name, "..", &next) && dir->super->imount)
+        // 目标目录 ".." 为上一级目录
+    if (match_name(name, "..", &next) \
+        // 当前目录为挂载设备的根目录
+        && dir == dir->super->iroot \
+        && dir->super->iroot != dir->super->imount)
     {
+        // 获取挂载设备的超级块
         super_t *super = dir->super;
+        // 将目录置换为挂载点目录
         inode = super->imount;
         inode->count++;
         iput(dir);

--- a/src/fs/namei.c
+++ b/src/fs/namei.c
@@ -66,7 +66,10 @@ inode_t *named(char *pathname, char **next)
     inode_t *inode = NULL;
     while (true)
     {
-        if (match_name(name, "..", next) && dir->super->imount)
+        if (match_name(name, "..", &next)
+            && dir == dir->super->iroot
+            && dir->super->iroot != dir->super->imount
+        )
         {
             super_t *super = dir->super;
             inode = super->imount;
@@ -111,11 +114,10 @@ inode_t *namei(char *pathname)
     char *name = next;
     inode_t *inode = NULL;
 
-        // 目标目录 ".." 为上一级目录
-    if (match_name(name, "..", &next) \
-        // 当前目录为挂载设备的根目录
-        && dir == dir->super->iroot \
-        && dir->super->iroot != dir->super->imount)
+    if (match_name(name, "..", &next)
+        && dir == dir->super->iroot
+        && dir->super->iroot != dir->super->imount
+    )
     {
         // 获取挂载设备的超级块
         super_t *super = dir->super;


### PR DESCRIPTION
onix/src/fs/namei.c : ---> func: namei
🐛 当参数为 “..” 时，namei返回错误的inode: dir->super->imount
triggle occasion:
![namei_bug_test](https://github.com/StevenBaby/onix/assets/115213460/4d97b6a6-0695-4170-8191-e306aa88f48e)

onix/src/fs/fsyscall.c: ---> func: sys_open
🐛 部分旧版本GCC编译器(ex: gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0)默认标准不允许在标签之后声明变量
url: https://stackoverflow.com/questions/8384388/variable-declaration-after-goto-label
