### PR TITLE
🐛 修复kfree函数中释放内核页的顺序问题

### DIFF
--- a/src/kernel/arena.c
+++ b/src/kernel/arena.c
@@ -131,8 +131,9 @@ void kfree(void *ptr)
             list_remove(block);
             assert(!list_search(&arena->desc->free_list, block));
         }
-        free_kpage((u32)arena, 1);
         arena->desc->page_count--;
         assert(arena->desc->page_count >= BUF_COUNT);
+
+        free_kpage((u32)arena, 1);
     }
 }


### PR DESCRIPTION
关于arena.cc文件里面的kfree函数的实现，free_kpage调用顺序的纠正#41。