### PR TITLE
🐛 漏洞修复：修改了系统中mapping_init函数的bug

### DIFF
--- a/src/kernel/memory.c
+++ b/src/kernel/memory.c
@@ -278,6 +278,7 @@ void mapping_init()
             page_entry_t *tentry = &pte[tidx];
             entry_init(tentry, index);
             tentry->user = USER_MEMORY; // 只能被内核访问
+            if(memory_map[index] == 0) free_pages--;
             memory_map[index] = 1;      // 设置物理内存数组，该页被占用
         }
     }


### PR DESCRIPTION
在memory_init函数里面第一次初始化free_pages为IDX(memory_size)即1M往后所有的页，第二次memory_map_init里面将free_page减掉了物理内存数组占用的页数，此时free_pge是包含内核可用空间的，而作者在mapping_init函数初始化内核的内存页表页目录时，直接修改物理内存数组memory_map，没有更新free_page的值，这会导致free_page比实际可用物理内存要大。