### PR TITLE
修复TCP拆包后数据错误问题

### DIFF
--- a/src/net/tcp.c
+++ b/src/net/tcp.c
@@ -377,7 +377,7 @@ static int tcp_sendmsg(socket_t *s, msghdr_t *msg, u32 flags)
             continue;
 
         int len = left < iov->size ? left : iov->size;
-        tcp_enqueue(pcb, iov->base, left, flags);
+        tcp_enqueue(pcb, iov->base, len, flags);
         left -= len;
     }
     tcp_output(pcb);

--- a/src/net/tcp_output.c
+++ b/src/net/tcp_output.c
@@ -47,6 +47,7 @@ err_t tcp_enqueue(tcp_pcb_t *pcb, void *data, size_t size, int flags)
     ip_t *ip;
     tcp_t *tcp;
     pbuf_t *pbuf;
+    void *data_ptr=data;
 
     if (pcb->snd_mss < TCP_DEFAULT_MSS)
         pcb->snd_mss = TCP_DEFAULT_MSS;
@@ -81,11 +82,13 @@ err_t tcp_enqueue(tcp_pcb_t *pcb, void *data, size_t size, int flags)
         tcp->flags |= flags;
 
         int seglen = (pcb->snd_mss - pbuf->size);
-        seglen=15;
         int len = left < seglen ? left : seglen;
 
-        if (left > 0)
-            memcpy(pbuf->data + pbuf->size, data, len);
+        if (len > 0)
+        {
+            memcpy(pbuf->data + pbuf->size, data_ptr, len);
+            data_ptr+=len;
+        }
 
         pcb->snd_nbb += len;
         pbuf->size += len;

--- a/src/net/tcp_output.c
+++ b/src/net/tcp_output.c
@@ -81,6 +81,7 @@ err_t tcp_enqueue(tcp_pcb_t *pcb, void *data, size_t size, int flags)
         tcp->flags |= flags;
 
         int seglen = (pcb->snd_mss - pbuf->size);
+        seglen=15;
         int len = left < seglen ? left : seglen;
 
         if (left > 0)

--- a/src/net/tcp_output.c
+++ b/src/net/tcp_output.c
@@ -47,7 +47,7 @@ err_t tcp_enqueue(tcp_pcb_t *pcb, void *data, size_t size, int flags)
     ip_t *ip;
     tcp_t *tcp;
     pbuf_t *pbuf;
-    void *data_ptr=data;
+    void *ptr = data;
 
     if (pcb->snd_mss < TCP_DEFAULT_MSS)
         pcb->snd_mss = TCP_DEFAULT_MSS;
@@ -86,8 +86,8 @@ err_t tcp_enqueue(tcp_pcb_t *pcb, void *data, size_t size, int flags)
 
         if (len > 0)
         {
-            memcpy(pbuf->data + pbuf->size, data_ptr, len);
-            data_ptr+=len;
+            memcpy(pbuf->data + pbuf->size, ptr, len);
+            ptr += len;
         }
 
         pcb->snd_nbb += len;

--- a/tests/net/tcp_server.py
+++ b/tests/net/tcp_server.py
@@ -15,9 +15,7 @@ conn, addr = s.accept()
 print(conn)
 print(addr)
 
-data1 = conn.recv(1024)
-data2 = conn.recv(1024)
-data=data1+data2
+data = conn.recv(1024)
 print("recv:", data.decode())
 conn.send(f"hello client {int(time.time())}".encode())
 time.sleep(1)

--- a/tests/net/tcp_server.py
+++ b/tests/net/tcp_server.py
@@ -15,7 +15,9 @@ conn, addr = s.accept()
 print(conn)
 print(addr)
 
-data = conn.recv(1024)
+data1 = conn.recv(1024)
+data2 = conn.recv(1024)
+data=data1+data2
 print("recv:", data.decode())
 conn.send(f"hello client {int(time.time())}".encode())
 time.sleep(1)


### PR DESCRIPTION
如果TCP数据包大于snd_mss，就会进行拆包，但是拆包后数据发生了错误，如下图所示：
![tcp-check](https://github.com/StevenBaby/onix/assets/1438210/a58057e0-5687-4cff-ad79-2f222b92f6c3)

此PR可以修复这个问题。